### PR TITLE
Run Psalm using PHP 8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8-cli-alpine as build-extensions
+FROM php:8.0-cli-alpine as build-extensions
 RUN docker-php-ext-install pcntl posix
 
 FROM composer:2 as composer-fetch


### PR DESCRIPTION
At least the older Psalm images (4.10.0) cannot deal with deprecations raised by PHP 8.1 when tenative return types (https://php.watch/versions/8.1/internal-method-return-types) are missing. This is a problem on older code bases when e. g. a `mixed` return type hint cannot be used (PHP < 8.0).

On the other hand, it seems at least newer Psalm versions can deal with this (https://github.com/vimeo/psalm/pull/6732?)