### PR TITLE
Use absolute path to call psalm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,6 @@ COPY --from=build-extensions /usr/local/lib/php /usr/local/lib/php
 COPY --from=build-extensions /usr/local/etc/php /usr/local/etc/php
 COPY --from=composer-fetch /composer /composer
 
-ENV PATH /composer/vendor/bin:${PATH}
-
 # Satisfy Psalm's quest for a composer autoloader (with a symlink that disappears once a volume is mounted at /app)
 
 RUN mkdir /app && ln -s /composer/vendor/ /app/vendor

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh -l
 set -e
 
-psalm --threads=$(nproc) "$@"
+/composer/vendor/bin/psalm --threads=$(nproc) "$@"


### PR DESCRIPTION
Since three weeks, calling `psalm` in the `entrypoint.sh` script doesn't work anymore, the binary is not found, as though `PATH` is expanded to `/composer/vendor/bin` in the `Dockerfile`. I hove no idea why that is, but it should be better to call `/composer/vendor/bin/psalm` by it's absolute path anyways.