### PR TITLE
Revert workaround to disable JIT

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,4 @@
 #!/bin/sh -l
 set -e
 
-echo -- Disabling JIT for Psalm as a workaround for https://github.com/vimeo/psalm/issues/11723
-echo -- You can ignore the JIT-related error message below
-echo
-
-PSALM_ALLOW_XDEBUG=1 /composer/vendor/bin/psalm --threads=$(nproc) "$@"
+/composer/vendor/bin/psalm --threads=$(nproc) "$@"


### PR DESCRIPTION
This reverts commit 6cbe7627392bfb17a1a14b66c6ec333287a309be, since https://github.com/vimeo/psalm/issues/11723 has been fixed in Psalm 6.16.1.
